### PR TITLE
Use %-formatting instead of trying ruby #{key}

### DIFF
--- a/src/main/python/neo4j/core.py
+++ b/src/main/python/neo4j/core.py
@@ -96,7 +96,7 @@ class PropertyContainer(extends(PropertyContainer)):
         if v != None: 
             return v
         
-        raise KeyError("No property with key #{key}.")
+        raise KeyError("No property with key %r." % (key,))
             
     def __setitem__(self, key, value):
         self.set_property(key, value)


### PR DESCRIPTION
`raise KeyError("No property with key #{key}.")` doesn't get the key value to the raised error.
